### PR TITLE
Fix RFC 8894 violations in CA caps

### DIFF
--- a/src/scep/Client/client.py
+++ b/src/scep/Client/client.py
@@ -27,8 +27,9 @@ class Client:
         res = requests.get(self.url, params={'operation': 'GetCACaps', 'message': message})
         if res.status_code != 200:
             raise ValueError('Got invalid status code for GetCACaps: {}'.format(res.status_code))
-        caps = res.text.split("\n")
-        cacaps = {CACaps(cap.strip()) for cap in caps if cap.strip() != ''}
+        caps = [cap.strip().lower() for cap in res.text.splitlines() if cap.strip()]
+        reverse_cacaps = dict([(cap.value.lower(), cap) for cap in CACaps])
+        cacaps = {reverse_cacaps[cap] for cap in caps if cap in reverse_cacaps}
         return Capabilities(cacaps)
 
     def get_ca_certs(self, identifier=None):


### PR DESCRIPTION
The Client.get_ca_capabilities() method doesn't follow the SCEP
specification. As section 3.5.2 in RFC 8894 states:
- Both <cr><lf> and <lf> must be accepted as delimiters. Using
  splitlines() is safer therefore.
- Unknown keywords must be ignored.
- Clients should ignore the case of the keywords.