### PR TITLE
Not able to find ca and ra properly

### DIFF
--- a/src/scep/Client/responses.py
+++ b/src/scep/Client/responses.py
@@ -150,7 +150,7 @@ class CACertificates:
     def _filter(self, required_key_usage, not_required_key_usage, ca_only=False):
         matching_certificates = list()
         for cert in self._certificates:
-            if (cert.is_ca != ca_only) or \
+            if (bool(cert.is_ca) != ca_only) or \
                     (required_key_usage.intersection(cert.key_usage) != required_key_usage) or \
                     (not_required_key_usage.difference(cert.key_usage) != not_required_key_usage):
                 continue


### PR DESCRIPTION
when more than one certificates (different CA and RA) are returned by Client.get_ca_certs() functions.

the comparison

(cert.is_ca != ca_only)

will return True if

cert.is_ca == None
ca_only   == False

in

digital_sign = self._filter(required_key_usage=required, not_required_key_usage=not_required, ca_only=False)

return wrong certificate